### PR TITLE
Removed options_element dependency, added version

### DIFF
--- a/webform_civicrm.info
+++ b/webform_civicrm.info
@@ -1,10 +1,9 @@
 name = Webform CiviCRM Integration
 description = A powerful, flexible, user-friendly form builder for CiviCRM.
 backdrop = 1.x
+version = 1.x-1.0.1
 type = module
 package = CiviCRM
 dependencies[] = civicrm (>=4.4)
 dependencies[] = webform
 dependencies[] = libraries
-dependencies[] = options_element
-# TODO: uncomment the dependency below once the module has been ported


### PR DESCRIPTION
Third time's a charm?

The `options_element` module doesn't seem to be needed in order for `webform_civicrm` to work properly with Backdrop; I've been running without it for a long time with no ill effects. I think that most of the module's functionality has been integrated into Backdrop core.

I also added the current version number to `webform_civicrm.info`.