### PR TITLE
Updated minimum CiviCRM version value to match new Backdrop format.

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -10,7 +10,7 @@
 /**
  * The versions of CiviCRM and WebForm. Min is >=.  Max is <. FALSE = no MAX
  */
-define('WEBFORM_CIVICRM_CIVICRM_VERSION_MIN', '4.4');
+define('WEBFORM_CIVICRM_CIVICRM_VERSION_MIN', '1.x-4.7.0');
 define('WEBFORM_CIVICRM_CIVICRM_VERSION_MAX', FALSE);
 
 define('WEBFORM_CIVICRM_WEBFORM_VERSION', '1.x-1.1.0');


### PR DESCRIPTION
Resolves error on Backdrop status page due to different version format than expected; see https://github.com/backdrop-contrib/webform_civicrm/issues/16 for more info.