### PR TITLE
#19: Remove version check for CiviCRM

### DIFF
--- a/webform_civicrm.info
+++ b/webform_civicrm.info
@@ -3,7 +3,7 @@ description = A powerful, flexible, user-friendly form builder for CiviCRM.
 backdrop = 1.x
 type = module
 package = CiviCRM
-dependencies[] = civicrm (>=4.4)
+dependencies[] = civicrm
 dependencies[] = webform
 dependencies[] = libraries
 dependencies[] = options_element


### PR DESCRIPTION
No version prior to 4.7 works with Backdrop CMS anyway.