### PR TITLE
Remove duplicate 'WEBFORM_CIVICRM_DEFAULT_CONTACT_ID' definition

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -43,8 +43,6 @@ function webform_civicrm_autoload_info() {
 
 define('WEBFORM_CIVICRM_DEFAULT_CONTACT_ID', 1);
 
-define('WEBFORM_CIVICRM_DEFAULT_CONTACT_ID', 1);
-
 /**
  * Implements hook_menu().
  *


### PR DESCRIPTION
@herbdool

Overview
----------------------------------------

Seeing a lot of these due to duplicate defined constant:

`Notice: Constant WEBFORM_CIVICRM_DEFAULT_CONTACT_ID already defined in include_once() (line 46 of /path-to-site/modules/webform_civicrm/webform_civicrm.module).`