### PR TITLE
Update to match 7.x-4.24

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -778,13 +778,14 @@ function wf_crm_get_fields($var = 'fields') {
       'type' => 'select',
       'expose_list' => TRUE,
     );
+    $defaultLocType = CRM_Core_BAO_LocationType::getDefault();
     foreach (array('address' => t('Address # Location'), 'phone' => t('Phone # Location'), 'email' => t('Email # Location'), 'im' => t('IM # Location')) as $key => $label) {
       if (isset($sets[$key])) {
         $fields[$key . '_location_type_id'] = array(
           'name' => $label,
           'type' => 'select',
           'expose_list' => TRUE,
-          'value' => '1',
+          'value' => $defaultLocType->id,
         );
       }
     }

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -867,8 +867,18 @@ abstract class wf_crm_webform_base {
    * @return int|null
    */
   function addPaymentJs() {
-    CRM_Core_Resources::singleton()->addCoreResources();
-    CRM_Financial_Form_Payment::addCreditCardJs(NULL, 'html-header');
+    $currentVer = CRM_Core_BAO_Domain::version();
+    if (version_compare($currentVer, '5.8') <= 0 && method_exists('CRM_Core_Payment_Form', 'getCreditCardCSSNames')) {
+      $credit_card_types = CRM_Core_Payment_Form::getCreditCardCSSNames();
+      CRM_Core_Resources::singleton()
+        ->addCoreResources()
+        ->addSetting(array('config' => array('creditCardTypes' => $credit_card_types)))
+        ->addScriptFile('civicrm', 'templates/CRM/Core/BillingBlock.js', -10, 'html-header');
+    }
+    else {
+      CRM_Core_Resources::singleton()->addCoreResources();
+      CRM_Financial_Form_Payment::addCreditCardJs(NULL, 'html-header');
+    }
   }
 
   /**

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -867,11 +867,8 @@ abstract class wf_crm_webform_base {
    * @return int|null
    */
   function addPaymentJs() {
-    $credit_card_types = CRM_Core_Payment_Form::getCreditCardCSSNames();
-    CRM_Core_Resources::singleton()
-      ->addCoreResources()
-      ->addSetting(array('config' => array('creditCardTypes' => $credit_card_types)))
-      ->addScriptFile('civicrm', 'templates/CRM/Core/BillingBlock.js', -10, 'html-header');
+    CRM_Core_Resources::singleton()->addCoreResources();
+    CRM_Financial_Form_Payment::addCreditCardJs(NULL, 'html-header');
   }
 
   /**

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1915,6 +1915,14 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params['source'] = $this->settings['new_contact_source'];
     $params['item_name'] = $params['description'] = t('Webform Payment: @title', array('@title' => $this->node->title));
 
+    // We need the submitted billing params from the request (Eg. billing_country_id-5)
+    //  because that's how payment processors expect to find them.
+    foreach ($this->form_state['input'] as $formKey => $formValue) {
+      if (substr($formKey, 0, 8) === 'billing_') {
+        $params[$formKey] = $formValue;
+      }
+    }
+
     if (method_exists($paymentProcessor, 'setSuccessUrl')) {
       $paymentProcessor->setSuccessUrl($this->getIpnRedirectUrl('success'));
       $paymentProcessor->setCancelUrl($this->getIpnRedirectUrl('cancel'));


### PR DESCRIPTION
Overview
----------------------------------------
This update brings the Backdrop module up-to-date with Webform CiviCRM 7.x-4.24 for Drupal. See https://github.com/backdrop-contrib/webform_civicrm/issues/30

Before
----------------------------------------
Current release matches 7.x-4.23 release for Drupal.

After
----------------------------------------
This pull requests matches 7.x-4.24 release for Drupal.

Comments
----------------------------------------
I didn't spot any conflicts to resolve in this particular update; only three files changed!
