### PR TITLE
Fixed includes/wf_crm_webform_base.inc to match Drupal 7.x-4.25

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -884,8 +884,6 @@ abstract class wf_crm_webform_base {
 
   /**
    * CiviCRM JS can't be attached to a Backdrop form so have to manually re-add this during validation
-   *
-   * @return int|null
    */
   function addPaymentJs() {
     $currentVer = CRM_Core_BAO_Domain::version();


### PR DESCRIPTION
Overview
----------------------------------------
In pull request #33 I mistakenly included a commented line that had been removed from Drupal 7.x-4.25; I've corrected that here.

Before
----------------------------------------
`includes/wf_crm_webform_base.inc` still included the commented ` @return int|null` line.

After
----------------------------------------
I've removed that line and a preceding blank comment line to better match the Drupal 7.x-4.25 module.