### PR TITLE
Update to match Drupal 7.x-4.26

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -1148,6 +1148,7 @@ function wf_crm_results_display_options($contact_type) {
     'city' => t("City"),
     'county' => t("District/County"),
     'state_province' => t("State/Province"),
+    'street_address' => t("Street Address"),
     'country' => t("Country"),
     'postal_code' => t("Postal Code"),
     'phone' => t("Phone"),

--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -241,15 +241,18 @@ function _webform_edit_civicrm_contact($component) {
       '#parents' => array('extra', 'default_relationship'),
     );
   }
-  $form['defaults']['default']['#options']['custom_ref'] = t('Custom reference field');
-  $form['defaults']['default_custom_ref'] = array(
-    '#type' => 'select',
-    '#title' => t('Specify Custom Field'),
-    '#options' => wf_crm_get_custom_ref_options(),
-    '#required' => TRUE,
-    '#default_value' => $component['extra']['default_custom_ref'],
-    '#parents' => array('extra', 'default_custom_ref'),
-  );
+  $custom_ref_options = wf_crm_get_custom_ref_options();
+  if ($custom_ref_options) {
+    $form['defaults']['default']['#options']['custom_ref'] = t('Custom reference field');
+    $form['defaults']['default_custom_ref'] = array(
+      '#type' => 'select',
+      '#title' => t('Specify Custom Field'),
+      '#options' => $custom_ref_options,
+      '#required' => TRUE,
+      '#default_value' => $component['extra']['default_custom_ref'],
+      '#parents' => array('extra', 'default_custom_ref'),
+    );
+  }
   
   $case_count = isset($data['case']['number_of_case']) ? $data['case']['number_of_case'] : 0;
   if ($case_count > 0) {

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -1134,6 +1134,10 @@ function wf_crm_get_fields($var = 'fields') {
         'value' => 0,
         'exposed_empty_option' => '- ' . t('Automatic') . ' -',
       );
+      $fields['participant_note'] = array(
+        'name' => t('Participant Notes'),
+        'type' => 'textarea',
+      );
       if (isset($sets['contribution'])) {
         $fields['participant_fee_amount'] = array(
           'name' => t('Participant Fee'),

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1971,7 +1971,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           }
         }
         catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
-          drupal_set_message(ts('Payment approval failed with message :') . $e->getMessage(),'error');
+          backdrop_set_message(ts('Payment approval failed with message :') . $e->getMessage(),'error');
           CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
         }
         $preApprovalParams = $paymentProcessor->getPreApprovalDetails($result['pre_approval_parameters']);

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1848,7 +1848,28 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params['webform_redirect_success'] = $this->getIpnRedirectUrl('success');
 
     if (method_exists($paymentProcessor, 'doTransferCheckout')) {
-      // doTransferCheckout is deprecated but some processors might still implement it.
+      /* Paypal Express checkout */
+	  if(wf_crm_aval($_POST, 'credit_card_number') == 'express'){
+		try {
+		  $params['button'] = 'express';
+		  $params['component'] = 'contribute';
+		  $result = $paymentProcessor->doPreApproval($params);
+		  if (empty($result)) {
+			// This could happen, for example, when paypal looks at the button value & decides it is not paypal express.
+			return;
+		  }
+		}
+		catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
+		  drupal_set_message(ts('Payment approval failed with message :') . $e->getMessage(),'error');
+		  CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
+		}
+		$preApprovalParams = $paymentProcessor->getPreApprovalDetails($result['pre_approval_parameters']);
+		$params = array_merge($params, $preApprovalParams);
+		if (!empty($result['redirect_url'])) {
+		  CRM_Utils_System::redirect($result['redirect_url']);
+		}
+	  }
+	  // doTransferCheckout is deprecated but some processors might still implement it.
       // Somewhere around 4.6 it was replaced by doPayment as the method of choice,
       // but to be safe still call it if it exists for now.
       $paymentProcessor->doTransferCheckout($params, 'contribute');

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1848,28 +1848,28 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params['webform_redirect_success'] = $this->getIpnRedirectUrl('success');
 
     if (method_exists($paymentProcessor, 'doTransferCheckout')) {
-      /* Paypal Express checkout */
-	  if(wf_crm_aval($_POST, 'credit_card_number') == 'express'){
-		try {
-		  $params['button'] = 'express';
-		  $params['component'] = 'contribute';
-		  $result = $paymentProcessor->doPreApproval($params);
-		  if (empty($result)) {
-			// This could happen, for example, when paypal looks at the button value & decides it is not paypal express.
-			return;
-		  }
-		}
-		catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
-		  drupal_set_message(ts('Payment approval failed with message :') . $e->getMessage(),'error');
-		  CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
-		}
-		$preApprovalParams = $paymentProcessor->getPreApprovalDetails($result['pre_approval_parameters']);
-		$params = array_merge($params, $preApprovalParams);
-		if (!empty($result['redirect_url'])) {
-		  CRM_Utils_System::redirect($result['redirect_url']);
-		}
-	  }
-	  // doTransferCheckout is deprecated but some processors might still implement it.
+      //Paypal Express checkout
+      if(wf_crm_aval($_POST, 'credit_card_number') == 'express'){
+        try {
+          $params['button'] = 'express';
+          $params['component'] = 'contribute';
+          $result = $paymentProcessor->doPreApproval($params);
+            if (empty($result)) {
+            // This could happen, for example, when paypal looks at the button value & decides it is not paypal express.
+            return;
+          }
+        }
+        catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
+          drupal_set_message(ts('Payment approval failed with message :') . $e->getMessage(),'error');
+          CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
+        }
+        $preApprovalParams = $paymentProcessor->getPreApprovalDetails($result['pre_approval_parameters']);
+        $params = array_merge($params, $preApprovalParams);
+        if (!empty($result['redirect_url'])) {
+          CRM_Utils_System::redirect($result['redirect_url']);
+        }
+      }
+      // doTransferCheckout is deprecated but some processors might still implement it.
       // Somewhere around 4.6 it was replaced by doPayment as the method of choice,
       // but to be safe still call it if it exists for now.
       $paymentProcessor->doTransferCheckout($params, 'contribute');

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -4,7 +4,6 @@
 
 var wfCivi = (function ($, D) {
   'use strict';
-  var setting = D.settings.webform_civicrm;
   /**
    * Public methods.
    */
@@ -137,7 +136,7 @@ var wfCivi = (function ($, D) {
         if (clear) {
           // Reset country to default
           if (n[5] === 'country') {
-            $('select.civicrm-processed', this).val(setting.defaultCountry).trigger('change', 'webform_civicrm:reset');
+            $('select.civicrm-processed', this).val(D.settings.webform_civicrm.defaultCountry).trigger('change', 'webform_civicrm:reset');
           }
           //Set default value if it is specified in component settings.
           else if ($el.hasClass('webform-component-date') && typeof defaults != "undefined" && defaults.hasOwnProperty(name)) {
@@ -268,7 +267,7 @@ var wfCivi = (function ($, D) {
       fillOptions(stateSelect, stateProvinceCache[countryId]);
     }
     else {
-      $.getJSON(setting.callbackPath+'/stateProvince/'+countryId, function(data) {
+      $.getJSON(D.settings.webform_civicrm.callbackPath + '/stateProvince/' + countryId, function(data) {
         fillOptions(stateSelect, data);
         stateProvinceCache[countryId] = data;
       });
@@ -290,7 +289,7 @@ var wfCivi = (function ($, D) {
         fillOptions(countySelect, null);
       }
       else {
-        $.getJSON(setting.callbackPath+'/county/'+stateVal+'-'+countryId, function(data) {
+        $.getJSON(D.settings.webform_civicrm.callbackPath + '/county/' + stateVal + '-' + countryId, function(data) {
           fillOptions(countySelect, data);
         });
       }
@@ -364,10 +363,10 @@ var wfCivi = (function ($, D) {
 
   D.behaviors.webform_civicrmForm = {
     attach: function (context) {
-      if (!stateProvinceCache['default'] && setting) {
-        stateProvinceCache['default'] = setting.defaultStates;
-        stateProvinceCache[setting.defaultCountry] = setting.defaultStates;
-        stateProvinceCache[''] = {'': setting.noCountry};
+      if (!stateProvinceCache['default'] && D.settings.webform_civicrm) {
+        stateProvinceCache['default'] = D.settings.webform_civicrm.defaultStates;
+        stateProvinceCache[D.settings.webform_civicrm.defaultCountry] = D.settings.webform_civicrm.defaultStates;
+        stateProvinceCache[''] = {'': D.settings.webform_civicrm.noCountry};
       }
 
       // Replace state/prov & county textboxes with dynamic select lists


### PR DESCRIPTION
Overview
----------------------------------------
This update brings the Backdrop module up-to-date with Webform CiviCRM 7.x-4.26 for Drupal. See #30 for more info.

Before
----------------------------------------
Current release matches 7.x-4.25 release for Drupal.

After
----------------------------------------
This pull requests matches 7.x-4.26 release for Drupal.

Comments
----------------------------------------
Another easy merge, one instance of drupal_set_message to replace, no conflicts. Tested on my local, looks good from here!
