### PR TITLE
Update token-input.css

### DIFF
--- a/css/token-input.css
+++ b/css/token-input.css
@@ -43,7 +43,7 @@ form li.token-input-token {
     height: 1%;
     margin: 3px;
     padding: 3px 5px;
-    background-color: #d0efa0;
+    background-color: #eaeaea;
     color: #000;
     font-weight: bold;
     cursor: default;
@@ -51,7 +51,7 @@ form li.token-input-token {
 }
 
 form .webform-component.static li.token-input-token {
-    background-color: #D9E4C9;
+    background-color: #eaeaea;
 }
 
 form li.token-input-token p {
@@ -118,7 +118,7 @@ div.token-input-dropdown ul li em {
 }
 
 div.token-input-dropdown ul li.token-input-selected-dropdown-item {
-    background-color: #d0efa0;
+    background-color: #eaeaea;
 }
 
 form.contact-loading,


### PR DESCRIPTION
Overview
----------------------------------------
Unfortunately there is no standardized or universal Backdrop "soft highlight"-type selector such as .field-highlight that offers a theme-adaptive soft color for form fields. But my assertion is that light gray is probably a more copacetic assumption than pale green for most themes.

D7 or D8?
----------------------------------------
_Is this PR for D7WFC or for D8WFC? If D7WFC -> are you adding another PR for D8WFC? If D8WFC -> are you adding another PR for D7WFC?._

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
